### PR TITLE
Rename ScreenInfo.primary to ScreenInfo.isPrimary

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -296,7 +296,7 @@ dictionary ScreenInfo {
   long availTop;   // Top edge of the available screen area, e.g. 0
 
   // New properties critical for many multi-screen window placement use cases.
-  boolean primary;       // If this screen is designated as the 'primary' screen
+  boolean isPrimary;     // If this screen is designated as the 'primary' screen
                          // by the OS (otherwise it is 'secondary'), e.g. true
                          // Useful for placing prominent vs peripheral windows.
   boolean internal;      // If this screen is an 'internal' display, built into
@@ -336,7 +336,7 @@ async function getScreenForSlideshow() {
   // NEW: Returns a snapshot of information about connected screens on success.
   let screens = await window.getScreens();
   // Prefer an external screen, or failing that, a secondary screen.
-  return screens.find(s => !s.internal) ?? screens.find(s => !s.primary);
+  return screens.find(s => !s.internal) ?? screens.find(s => !s.isPrimary);
 }
 
 document.getElementById("multi-screen-slideshow").onclick = async function() {

--- a/index.bs
+++ b/index.bs
@@ -7,6 +7,7 @@ URL: https://webscreens.github.io/window-placement
 Level: 1
 Editor: Victor Costan, Google Inc. https://google.com, costan@google.com
 Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com
+Repository: webscreens/window-placement
 Group: secondscreencg
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/screen_enumeration
 Logo: logo.svg
@@ -259,7 +260,7 @@ dictionary ScreenInfo {
   long availTop;   // Top edge of the available screen area, e.g. 0
 
   // New properties critical for many multi-screen window placement use cases.
-  boolean primary;
+  boolean isPrimary;
   boolean internal;
   float scaleFactor;     // Ratio between physical pixels and device
                          // independent pixels for this screen, e.g. 2

--- a/index.html
+++ b/index.html
@@ -1221,10 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 703d95ed, updated Wed Aug 26 21:59:02 2020 +0300" name="generator">
+  <meta content="Bikeshed version 5f7b0e20, updated Tue Aug 18 15:46:28 2020 -0700" name="generator">
   <link href="https://webscreens.github.io/window-placement" rel="canonical">
   <link href="logo.svg" rel="icon">
-  <meta content="4ed2de1a74c7f0ec607f1106f580dedccbc3003b" name="document-revision">
 <style>
 .domintro::before {
     content: 'For web developers (non-normative)';
@@ -1500,7 +1499,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://w3.org/community/webscreens/"> <img alt="Logo" height="100" src="logo.svg" width="100"> </a> </p>
    <h1 class="p-name no-ref" id="title">Multi-Screen Window Placement</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-08-26">26 August 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-09-14">14 September 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1714,7 +1713,7 @@ However, <a data-link-type="dfn" href="#internal" id="ref-for-internal②">inter
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑦"><c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="ScreenInfo" data-dfn-type="dict-member" data-export data-type="long " id="dom-screeninfo-availtop"><code><c- g>availTop</c-></code><a class="self-link" href="#dom-screeninfo-availtop"></a></dfn>;   // Top edge of the available screen area, e.g. 0
 
   // New properties critical for many multi-screen window placement use cases.
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="idl-code" data-dfn-for="ScreenInfo" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-screeninfo-primary"><code><c- g>primary</c-></code><a class="self-link" href="#dom-screeninfo-primary"></a></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="idl-code" data-dfn-for="ScreenInfo" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-screeninfo-isprimary"><code><c- g>isPrimary</c-></code><a class="self-link" href="#dom-screeninfo-isprimary"></a></dfn>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <dfn class="idl-code" data-dfn-for="ScreenInfo" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-screeninfo-internal"><code><c- g>internal</c-></code><a class="self-link" href="#dom-screeninfo-internal"></a></dfn>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float"><c- b>float</c-></a> <dfn class="idl-code" data-dfn-for="ScreenInfo" data-dfn-type="dict-member" data-export data-type="float " id="dom-screeninfo-scalefactor"><code><c- g>scaleFactor</c-></code><a class="self-link" href="#dom-screeninfo-scalefactor"></a></dfn>;     // Ratio between physical pixels and device
                          // independent pixels for this screen, e.g. 2
@@ -1985,6 +1984,7 @@ Thomas Steiner,</p>
      <li><a href="#dom-screeninfo-internal">dict-member for ScreenInfo</a><span>, in §3</span>
     </ul>
    <li><a href="#dom-window-ismultiscreen">isMultiScreen()</a><span>, in §3</span>
+   <li><a href="#dom-screeninfo-isprimary">isPrimary</a><span>, in §3</span>
    <li><a href="#dom-screeninfo-left">left</a><span>, in §3</span>
    <li><a href="#dom-fullscreenoptions-navigationui">navigationUI</a><span>, in §3.2</span>
    <li><a href="#dom-window-onscreenschange">onscreenschange</a><span>, in §3.1</span>
@@ -1992,12 +1992,7 @@ Thomas Steiner,</p>
    <li><a href="#dom-screeninfo-orientationtype">orientationType</a><span>, in §3</span>
    <li><a href="#enumdef-permissionname">PermissionName</a><span>, in §3.2</span>
    <li><a href="#dom-screeninfo-pixeldepth">pixelDepth</a><span>, in §3</span>
-   <li>
-    primary
-    <ul>
-     <li><a href="#primary">definition of</a><span>, in §2.8</span>
-     <li><a href="#dom-screeninfo-primary">dict-member for ScreenInfo</a><span>, in §3</span>
-    </ul>
+   <li><a href="#primary">primary</a><span>, in §2.8</span>
    <li><a href="#dom-screeninfo-scalefactor">scaleFactor</a><span>, in §3</span>
    <li><a href="#dom-fullscreenoptions-screen">screen</a><span>, in §3.2</span>
    <li><a href="#screen-area">screen area</a><span>, in §2.3</span>
@@ -2218,7 +2213,7 @@ Thomas Steiner,</p>
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><c- b>long</c-></a> <a data-type="long " href="#dom-screeninfo-availtop"><code><c- g>availTop</c-></code></a>;   // Top edge of the available screen area, e.g. 0
 
   // New properties critical for many multi-screen window placement use cases.
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><c- b>boolean</c-></a> <a data-type="boolean " href="#dom-screeninfo-primary"><code><c- g>primary</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><c- b>boolean</c-></a> <a data-type="boolean " href="#dom-screeninfo-isprimary"><code><c- g>isPrimary</c-></code></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><c- b>boolean</c-></a> <a data-type="boolean " href="#dom-screeninfo-internal"><code><c- g>internal</c-></code></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float"><c- b>float</c-></a> <a data-type="float " href="#dom-screeninfo-scalefactor"><code><c- g>scaleFactor</c-></code></a>;     // Ratio between physical pixels and device
                          // independent pixels for this screen, e.g. 2


### PR DESCRIPTION
Addresses feedback from #32.

I couldn't figure out how to get the isPrimary definition in the <xmp class=idl> block to link to the <dfn>primary</dfn>. Tips appreciated, but that probably isn't blocking.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/window-placement/pull/34.html" title="Last updated on Sep 15, 2020, 12:12 AM UTC (6233c70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/window-placement/34/a1e6c7c...6233c70.html" title="Last updated on Sep 15, 2020, 12:12 AM UTC (6233c70)">Diff</a>