### PR TITLE
Update the Explainer's proposed API shape to address recent feedback

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -60,7 +60,7 @@ of existing window placement APIs to support extended multi-screen environments.
   * Extend `Window.open()` and `moveTo()/moveBy()` for cross-screen coordinates
 * Provide requisite information to achieve the goals above
   * Add `Screen.isExtended` to expose the presence of extended screen areas
-  * Add `Screen.onchange`, an event fired when Screen attributes change
+  * Add `Screen.change`, an event fired when Screen attributes change
   * Add `Window.getScreens()` to request additional permission-gated screen info
   * Add `Screens` and `ScreenAugmented` interfaces for additional screen info
   * Standardize common `Screen.availLeft` and `Screen.availTop` attributes
@@ -256,11 +256,11 @@ function updateSlideshowButtons() {
 }
 ```
 
-### Add `Screen.onchange`, an event fired when Screen attributes change
+### Add `Screen.change`, an event fired when Screen attributes change
 
 Sites must currently poll the existing `Screen` interface for changes, which is
 a development burden. This can easily be solved by adding an event that is fired
-when screen attributes change. The proposed shape is a `Screen.onchange` event,
+when screen attributes change. The proposed shape is a `Screen.change` event,
 exposed to secure contexts without an explicit permission prompt.
 
 ```webidl


### PR DESCRIPTION
This PR updates the Explainer's proposed API shape to address recent feedback. Please take a look; thanks!

Here's a recap of the rationale, and unique advantages over previous iterations of this proposal:
* Access to the multi-screen change EventTarget is gated by a permission (#30)
* Screen information is synchronously available in event handlers functions (#30)
* Unclear permission-gating of screen plurality information is resolved (#30)
* Naming has been updated for clarity and consistency with existing nomenclature (#29 & #31)
* Separate events are fired on screen array and per-screen changes (#12)
* The API exposes a more readily apparent currentScreen (#17)

Thanks for your help informing these changes: @pwnall, @jakearchibald, @kenchris, @jsbell, @tomayac