### PR TITLE
Update pointers to link capturing APIs.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -82,8 +82,7 @@ See explorations of alternative and supplemental proposals in
   * See the [Presentation](https://www.w3.org/TR/presentation-api/) and
     [Remote Playback](https://www.w3.org/TR/remote-playback/) APIs
 * Capturing links in specific existing/new windows, etc.
-  * See [Service Worker Launch Event](https://github.com/WICG/sw-launch) and
-    [PWAs as URL Handlers](https://github.com/WICG/pwa-url-handler/blob/master/explainer.md)
+  * See [Link Capturing](https://docs.google.com/document/d/1w9qHqVJmZfO07kbiRMd9lDQMW15DeK5o-p-rZyL7twk/edit?usp=sharing)
 
 ## Support requests to show elements fullscreen on a specific screen
 


### PR DESCRIPTION
For now, just link to the doc that explains the past and future plans
for link capturing. This has more context and is more understandable
than the launch handler and scope extensions explainers. When the
TODO about moving this document into the sw-launch repo is fixed, this
link should be updated again.