### PR TITLE
spec: sort screens by x, then y

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -516,14 +516,12 @@ The <dfn attribute for=ScreenDetails>screens</dfn> getter steps are:
 
 The <dfn>screen ordering</dfn> algorithm defines a [=/connected screen=] |a| as less than a [=/connected screen=] |b| if the following steps return true:
 
-1. If |a|'s [=connected screen/screen position=] y-coordinate is less than |b|'s [=connected screen/screen position=] y-coordinate, then return true.
-1. If |b|'s [=connected screen/screen position=] y-coordinate is less than |a|'s [=connected screen/screen position=] y-coordinate, then return false.
-1. If |a|'s [=connected screen/screen position=] x-coordinate is less than |b|'s [=connected screen/screen position=] x-coordinate, then return true.
-1. If |b|'s [=connected screen/screen position=] x-coordinate is less than |a|'s [=connected screen/screen position=] x-coordinate, then return false.
+1. If |a|'s [=connected screen/screen position=] x-coordinate is less than |b|'s [=connected screen/screen position=] y-coordinate, then return true.
+1. If |b|'s [=connected screen/screen position=] x-coordinate is less than |a|'s [=connected screen/screen position=] y-coordinate, then return false.
+1. If |a|'s [=connected screen/screen position=] y-coordinate is less than |b|'s [=connected screen/screen position=] x-coordinate, then return true.
+1. Otherwise, return false.
 
 </div>
-
-Issue: Should x or y have sort priority?
 
 The <dfn attribute for=ScreenDetails>currentScreens</dfn> getter steps are to return the {{ScreenDetailed}} object associated with the {{Window}} associated with [=/this=].
 

--- a/index.bs
+++ b/index.bs
@@ -516,9 +516,9 @@ The <dfn attribute for=ScreenDetails>screens</dfn> getter steps are:
 
 The <dfn>screen ordering</dfn> algorithm defines a [=/connected screen=] |a| as less than a [=/connected screen=] |b| if the following steps return true:
 
-1. If |a|'s [=connected screen/screen position=] x-coordinate is less than |b|'s [=connected screen/screen position=] y-coordinate, then return true.
-1. If |b|'s [=connected screen/screen position=] x-coordinate is less than |a|'s [=connected screen/screen position=] y-coordinate, then return false.
-1. If |a|'s [=connected screen/screen position=] y-coordinate is less than |b|'s [=connected screen/screen position=] x-coordinate, then return true.
+1. If |a|'s [=connected screen/screen position=] x-coordinate is less than |b|'s [=connected screen/screen position=] x-coordinate, then return true.
+1. If |b|'s [=connected screen/screen position=] x-coordinate is less than |a|'s [=connected screen/screen position=] x-coordinate, then return false.
+1. If |a|'s [=connected screen/screen position=] y-coordinate is less than |b|'s [=connected screen/screen position=] y-coordinate, then return true.
 1. Otherwise, return false.
 
 </div>


### PR DESCRIPTION
I think it makes more sense to sort screens left to right than
top to bottom.

This corresponds to this CL:
https://chromium-review.googlesource.com/c/chromium/src/+/3293985


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/quisquous/window-placement/pull/72.html" title="Last updated on Nov 22, 2021, 6:46 PM UTC (62c0f33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/window-placement/72/8a1503b...quisquous:62c0f33.html" title="Last updated on Nov 22, 2021, 6:46 PM UTC (62c0f33)">Diff</a>