### PR TITLE
Fix typo in description of internal screens

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -370,7 +370,7 @@ Each [=/connected screen=] may be designated as <dfn>internal</dfn> or <dfn>exte
 It is not unusual for an [=external=] screen to be disconnected from one computer system and connected to a different computer system.
 
 [=Internal=] screens are usually attached to a computer system at manufacturing time.
-[=Internal=] screens and are not intended to be detached by users.
+[=Internal=] screens are not intended to be detached by users.
 However, [=internal=] [=/connected screens=] may still appear and disappear while the user agent is running.
 
 Note:


### PR DESCRIPTION
"and are" -> "are"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/window-placement/pull/78.html" title="Last updated on Jan 8, 2022, 12:35 AM UTC (81e6ec7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/window-placement/78/1adcb7c...reillyeon:81e6ec7.html" title="Last updated on Jan 8, 2022, 12:35 AM UTC (81e6ec7)">Diff</a>