### PR TITLE
Move Joshua to former editor; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,31 @@
 
 # Window Management on the Web
 
-This repository considers web platform functionality to allow scripts to query
-the device for information about its screens, and place content on specific
-screens. The goals here are to explore background, use cases, and proposals for
-extending window placement capabilities of web applications on multi-screen
-devices.
+This repository contains the [Working Draft](https://www.w3.org/TR/window-management/) of the Window Management API web
+platform specification. The API extends window placement capabilities of web applications on multi-screen devices, by
+enabling script to query the device for information about its screens, and place content on specific screens. Developer
+documentation is available at [MDN's Window Management API page](https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API).
 
-See the [Editor’s Draft](https://w3c.github.io/window-management/) of the proposed specification.
-The [Explainer](https://github.com/w3c/window-management/blob/main/EXPLAINER.md),
-[Additional Explorations](https://github.com/w3c/window-management/blob/main/additional_explorations.md),
-and [Security and Privacy](https://github.com/w3c/window-management/blob/main/security_and_privacy.md)
-documents also have historical context and some deeper dives into these topics.
-File [new issues](https://github.com/w3c/window-management/issues/new/choose), reply to our
-[Discourse posting](https://discourse.wicg.io/t/proposal-supporting-window-placement-on-multi-screen-devices/3948),
-or reach out as you see fit with feedback, relevant use cases, and thoughts.
+The specification is being developed by the [W3C Second Screen Working Group](http://www.w3.org/2014/secondscreen/).
+Please see the group's [Work Mode](https://www.w3.org/wiki/Second_Screen/Work_Mode) for participation and contribution.
+File [new issues](https://github.com/w3c/window-management/issues/new) with feedback, relevant use cases, and thoughts.
 
-The specification is being developed by the
-[W3C Second Screen Working Group](http://www.w3.org/2014/secondscreen/). Please
-refer to the group's [Work Mode](https://www.w3.org/wiki/Second_Screen/Work_Mode)
-for instructions on how to contribute.
+The repository also explores other web platform requirements, use cases, and proposals for window management capabilities.
 
+The [Explainer](EXPLAINER.md), [Additional Explorations](additional_explorations.md), and [Security and Privacy](security_and_privacy.md)
+documents have historical context and some deeper dives into these topics.
+
+## Exploratory enhancements
+| Name | Link | Status |
+|------|------|--------|
+| Additional Windowing Controls | [Explainer](EXPLAINER_additional_windowing_controls.md), [Security and Privacy](security_and_privacy_additional_windowing_controls.md) | Incorporated into the main spec |
+| Fullscreen Popups | [Explainer](EXPLAINER_fullscreen_popups.md), [Security and Privacy](security_and_privacy_fullscreen_popups.md) | Inactive |
+| Initiating Multi-Screen Experiences | [Explainer](EXPLAINER_initiating_multi_screen_experiences.md), [Security and Privacy](security_and_privacy_initiating_multi_screen_experiences.md) | Inactive |
 
 ## Related explainers:
 | Name | Link |
 |------|------|
+| HTML Fullscreen Without A Gesture| [Explainer](https://github.com/explainers-by-googlers/html-fullscreen-without-a-gesture) |
 | Viewport Segments Property | [Explainer](https://github.com/WICG/visual-viewport/blob/gh-pages/segments-explainer/SEGMENTS-EXPLAINER.md)|
 | Visual Viewport API | [Draft Community Group Report](https://wicg.github.io/visual-viewport/), [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API) |
 | Form Factors Explained | [Draft Community Group Report](https://webscreens.github.io/form-factors/)

--- a/index.bs
+++ b/index.bs
@@ -6,8 +6,8 @@ Status: ED
 TR: https://www.w3.org/TR/window-management/
 URL: https://w3c.github.io/window-management/
 Level: None
-Editor: Joshua Bell, Google Inc. https://www.google.com/, jsbell@google.com, w3cid 61302
 Editor: Mike Wasserman, Google Inc. https://www.google.com/, msw@google.com, w3cid 116970
+Former editor: Joshua Bell, Google Inc. https://www.google.com/, jsbell@google.com, w3cid 61302
 Repository: w3c/window-management
 Group: secondscreenwg
 !Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/master/window-management">https://github.com/web-platform-tests/wpt/tree/master/window-management</a>


### PR DESCRIPTION
Joshua Bell has (sadly for us, happy for him) retired! Moving him to Former editor designation.
That hopefully fixes the editor group participation warning #159 

I have also updated the README regarding this repo status, MDN docs, and related work.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/michaelwasserman/window-management/pull/160.html" title="Last updated on Jul 14, 2026, 6:17 PM UTC (a92c23f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/window-management/160/ae0b0dc...michaelwasserman:a92c23f.html" title="Last updated on Jul 14, 2026, 6:17 PM UTC (a92c23f)">Diff</a>