### PR TITLE
Update auto-publish actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages


### PR DESCRIPTION
Apparently https://github.com/actions/checkout#checkout-v6 is the version that actually`Updated to the node24 runtime`.